### PR TITLE
Fix services page navigation links

### DIFF
--- a/services.html
+++ b/services.html
@@ -92,16 +92,16 @@
     <!-- Header & Navigation with Glass Effect -->
     <header class="sticky top-4 z-50 mx-auto max-w-7xl px-4">
         <nav class="glass-panel flex justify-between items-center p-4">
-            <a href="#" class="flex items-center space-x-3">
+            <a href="index.html" class="flex items-center space-x-3">
                 <img src="core-logo-blue-transparent.png" alt="Lefties Carpet Cleaning Logo" class="h-12" onerror="this.onerror=null;this.src='https://placehold.co/100x50/ffffff/0071B6?text=Lefties';">
             </a>
             <div class="hidden md:flex space-x-8 font-bold text-main">
-                <a href="#" class="text-primary-blue">Our Services</a>
-                <a href="#" class="hover:text-primary-blue transition-colors">Why Lefties?</a>
-                <a href="#" class="hover:text-primary-blue transition-colors">Gallery</a>
+                <a href="services.html" class="text-primary-blue">Our Services</a>
+                <a href="index.html#why-us" class="hover:text-primary-blue transition-colors">Why Lefties?</a>
+                <a href="index.html#gallery" class="hover:text-primary-blue transition-colors">Gallery</a>
             </div>
             <!-- ENHANCED BUTTON -->
-            <a href="#" class="bg-primary-blue text-white font-bold px-6 py-3 rounded-full hover:bg-blue-700 transition-all shadow-lg hover:shadow-xl transform hover:-translate-y-0.5" style="animation: pulse 2.5s infinite;">
+            <a href="index.html#quote" class="bg-primary-blue text-white font-bold px-6 py-3 rounded-full hover:bg-blue-700 transition-all shadow-lg hover:shadow-xl transform hover:-translate-y-0.5" style="animation: pulse 2.5s infinite;">
                 Get a Quote
             </a>
         </nav>


### PR DESCRIPTION
## Summary
- point services page logo to the home page
- link nav items to their destination sections

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f0aa1a9a08329a2837d60c356371b